### PR TITLE
fix: preserve file permissions when accepting test changes

### DIFF
--- a/tests/preserve_file_perms.t
+++ b/tests/preserve_file_perms.t
@@ -1,0 +1,19 @@
+  $ source $TESTDIR/scaffold
+
+Accepting changes on a file preserves the permissions on that file:
+
+  $ use test.janet <<EOF
+  > #!/usr/bin/env janet
+  > (use judge)
+  > (test 1 2)
+  > EOF
+
+  $ chmod 523 test.janet
+  $ ls -l test.janet | cut -d ' ' -f 1
+  -r-x-w--wx
+
+  $ judge test.janet --accept >/dev/null
+  [1]
+
+  $ ls -l test.janet | cut -d ' ' -f 1
+  -r-x-w--wx


### PR DESCRIPTION
Firstly, thanks a lot for this library! I've picked it up along with "Janet for Mortals" – being able to write expect tests for my scripts is really a joy.

This commit fixes what I think is a bug causing `judge --accept` to reset the file permissions of any modified test files back to the default of `0666 & umask`.

This happens because Judge first writes to a new `foo.janet.tested` file with default file permissions and then conditionally replaces `foo.janet` with that file. The PR fixes this by updating the permissions of the `.tested` file to match the original one immediately before performing the move.