### PR TITLE
Respect NO_COLOR environment variable

### DIFF
--- a/src/colorize.janet
+++ b/src/colorize.janet
@@ -1,3 +1,5 @@
+(def- no-color (os/getenv "NO_COLOR" false))
+
 (def- colors
   {:black 0
    :red 1
@@ -17,19 +19,25 @@
   (+ color-code offset))
 
 (defn fg [color & strs]
-  (string "\e[" (encode color foreground) "m" ;strs "\e[0m"))
+  (if-not no-color
+    (string "\e[" (encode color foreground) "m" ;strs "\e[0m")
+    (string ;strs)))
 
 (defn fgf [color & strs]
   (fg color (string/format ;strs)))
 
 (defn dim [& strs]
-  (string "\e[2m" ;strs "\e[0m"))
+  (if-not no-color
+    (string "\e[2m" ;strs "\e[0m")
+    (string ;strs)))
 
 (defn dimf [& strs]
   (dim (string/format ;strs)))
 
 (defn bg [color & strs]
-  (string "\e[" (encode color background) "m" ;strs "\e[0m"))
+  (if-not no-color
+    (string "\e[" (encode color background) "m" ;strs "\e[0m")
+    (string ;strs)))
 
 (defn bgf [color & strs]
   (bg color (string/format ;strs)))

--- a/tests/no-color.t
+++ b/tests/no-color.t
@@ -1,0 +1,25 @@
+  $ source $TESTDIR/scaffold
+  $ export NO_COLOR=1
+
+Does not export ANSI color codes:
+
+  $ use <<EOF
+  > (use judge)
+  > (deftest "test"
+  >   (test (+ 1 2)))
+  > EOF
+  $ judge
+  ! # script.janet
+  ! 
+  ! (deftest "test"
+  !   (test (+ 1 2))
+  !   (test (+ 1 2) 3))
+  ! 
+  ! 0 passed 1 failed
+  [1]
+
+  $ show_tested
+  (use judge)
+  (deftest "test"
+    (test (+ 1 2) 3))
+


### PR DESCRIPTION
Just a tiny pull to make Judge respect the [`NO_COLOR`](https://no-color.org/) environment variable.

Many cli's also have a flag or set of flags for this, didn't add that right off the bat, since it would be a bit more complicated and I am not sure how you would feel about that @ianthehenry?