### PR TITLE
Windows compatibility fix

### DIFF
--- a/src/runner.janet
+++ b/src/runner.janet
@@ -45,6 +45,7 @@ results)
   (if (deep= current-file-contents source)
     (do
       (os/chmod corrected-filename file-permissions)
+      (os/rm original-filename)
       (os/rename corrected-filename original-filename))
     (eprint
       (colorize/fgf :red "%s changed since test runner began; refusing to overwrite"


### PR DESCRIPTION
On windows, `os/rename` errors if the file already exists. 

This microscopic tweak changes nothing about behavior on *nix but fixes Judge's ability to accept changes on Windows.